### PR TITLE
Abstract WatsonAssistant calls

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -36,20 +36,20 @@ objects:
             path: /health/status
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 240
+          initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 15
+          timeoutSeconds: 1
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /health/status
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 240
+          initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 15
+          timeoutSeconds: 1
         env:
           - name: CLOWDER_ENABLED
             value: ${CLOWDER_ENABLED}
@@ -67,16 +67,20 @@ objects:
             value: ${CONSOLEDOT_BASE_URL}
           - name: SESSION_STORAGE
             value: ${SESSION_STORAGE}
+          - name: CONSOLE_ASSISTANT
+            value: ${CONSOLE_ASSISTANT}
           - name: WATSON_API_URL
             valueFrom:
               secretKeyRef:
                 name: virtual-assistant-watson
                 key: api.url
+                optional: true
           - name: WATSON_API_KEY
             valueFrom:
               secretKeyRef:
                 name: virtual-assistant-watson
                 key: api.key
+                optional: true
           - name: WATSON_ENV_ID
             value: ${WATSON_ENV_ID}
         resources:
@@ -107,10 +111,10 @@ objects:
             path: /health/status
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 10
+          initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 27
+          timeoutSeconds: 1
         readinessProbe:
           failureThreshold: 3
           httpGet:
@@ -120,7 +124,7 @@ objects:
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 30
+          timeoutSeconds: 1
         env:
           - name: CLOWDER_ENABLED
             value: ${CLOWDER_ENABLED}
@@ -161,7 +165,6 @@ parameters:
   value: redis
 - description: Watson environment id to use.
   name: WATSON_ENV_ID
-  required: true
 - description: Determines Clowder deployment
   name: CLOWDER_ENABLED
   value: "true"
@@ -187,6 +190,9 @@ parameters:
 - description: Server's max allowed header size
   name: SERVER_REQUEST_MAX_HEADER_SIZE
   value: "20000"
+- description: Default assistant to use in the console
+  name: CONSOLE_ASSISTANT
+  required: true
 - description: Watson extension authentication type
   name: WATSON_EXTENSION_AUTHENTICATION_TYPE
   required: true

--- a/services/virtual-assistant/.env.template
+++ b/services/virtual-assistant/.env.template
@@ -12,6 +12,9 @@
 # REDIS_USERNAME=
 # REDIS_PASSWORD=
 
+## Console assistant to use
+# CONSOLE_ASSISTANT=watson
+
 ## Watson keys
 # WATSON_API_URL=
 # WATSON_API_KEY=

--- a/services/virtual-assistant/src/run.py
+++ b/services/virtual-assistant/src/run.py
@@ -39,7 +39,7 @@ QuartSchema(
     ),
     servers=[
         Server(
-            url=f"http://{{env}}{config.base_url}",
+            url="http://{env}",
             description="Virtual assistant hosted services",
             variables={
                 "env": ServerVariable(
@@ -51,7 +51,11 @@ QuartSchema(
                     description="Available environments",
                 )
             },
-        )
+        ),
+        Server(
+            url=f"http://127.0.0.1:{config.port}",
+            description="Local development server",
+        ),
     ],
 )
 

--- a/services/virtual-assistant/src/virtual_assistant/assistant/__init__.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/__init__.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from virtual_assistant.api_types import TalkInput, TalkResponse
+
+# Todo: We need to create a common input/response that is not tied to watson
+type AssistantInput = TalkInput
+type AssistantResponse = TalkResponse
+
+
+class Assistant(ABC):
+    @abstractmethod
+    async def send_message(
+        self, session_id: Optional[str], user_id: str, message: AssistantInput
+    ) -> AssistantResponse: ...

--- a/services/virtual-assistant/src/virtual_assistant/assistant/echo.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/echo.py
@@ -1,0 +1,16 @@
+from . import Assistant, AssistantResponse, AssistantInput
+from virtual_assistant.api_types import TalkResponse
+
+
+class EchoAssistant(Assistant):
+    async def send_message(
+        self, session_id: str, user_id: str, message: AssistantInput
+    ) -> AssistantResponse:
+        return TalkResponse(
+            session_id="echo-session",
+            response=[
+                {
+                    "text": message["text"],
+                }
+            ],
+        )

--- a/services/virtual-assistant/src/virtual_assistant/config.py
+++ b/services/virtual-assistant/src/virtual_assistant/config.py
@@ -23,12 +23,17 @@ if session_storage == "redis":
     redis_hostname = config("REDIS_HOSTNAME")
     redis_port = config("REDIS_PORT")
 
-watson_api_url = config("WATSON_API_URL")
-watson_api_key = config("WATSON_API_KEY")
-watson_env_id = config("WATSON_ENV_ID")
-watson_env_version = config(
-    "WATSON_ENV_VERSION", default="2024-08-25"
-)  # Needs updating if watson releases breaking change. See: https://cloud.ibm.com/apidocs/assistant-v2?code=python#versioning
+
+console_assistant = config(
+    "CONSOLE_ASSISTANT", default="echo", cast=Choices(["echo", "watson"])
+)
+if console_assistant == "watson":
+    watson_api_url = config("WATSON_API_URL")
+    watson_api_key = config("WATSON_API_KEY")
+    watson_env_id = config("WATSON_ENV_ID")
+    watson_env_version = config(
+        "WATSON_ENV_VERSION", default="2024-08-25"
+    )  # Needs updating if watson releases breaking change. See: https://cloud.ibm.com/apidocs/assistant-v2?code=python#versioning
 
 
 def log_config():

--- a/services/virtual-assistant/src/virtual_assistant/routes/talk.py
+++ b/services/virtual-assistant/src/virtual_assistant/routes/talk.py
@@ -8,7 +8,7 @@ from quart_schema import validate_request, validate_response
 from common.auth import get_org_id_from_identity, require_identity_header
 from common.types.errors import ValidationError
 from virtual_assistant.api_types import TalkRequest, TalkResponse
-from virtual_assistant.watson import WatsonAssistant, format_response
+from virtual_assistant.assistant import Assistant
 
 blueprint = Blueprint("talk", __name__, url_prefix="/talk")
 
@@ -21,28 +21,27 @@ logger = logging.getLogger(__name__)
 @validate_response(TalkResponse, 200)
 @validate_response(ValidationError, 400)
 async def talk(
-    data: TalkRequest, assistant: injector.Inject[WatsonAssistant]
+    data: TalkRequest, assistant: injector.Inject[Assistant]
 ) -> TalkResponse:
     identity = request.headers.get("x-rh-identity")
     # Todo: Update to use user_id - org-id applies to multiple users
     org_id = get_org_id_from_identity(identity)
 
     # Todo: Get this from redis?
-    session_id = await assistant.create_session(data.session_id)
+    session_id = data.session_id
     logger.info(f"session_id: {session_id}")
 
     # Send message to Watson Assistant
     try:
-        watson_message_response = await assistant.send_watson_message(
+        response = await assistant.send_message(
             session_id=session_id,
             user_id=org_id,  # using org_id as user_id to identity unique users
-            input=data.input.model_dump(exclude_none=True),
+            message=data.input.model_dump(exclude_none=True),
         )
     except ApiException as e:
         # Todo: Should we just let raise this error and let the handler wrap it into a validation error?
         return ValidationError(message=e.message), 400
 
-    response = format_response(session_id, watson_message_response)
     # Todo: Check if this syntax is OK - should we update the return type to be Tuple[TalkResponse, 200] or
     # verify if the validate_response decorator adds the http code for us
     return response, 200

--- a/services/virtual-assistant/tests/routes/test_talk.py
+++ b/services/virtual-assistant/tests/routes/test_talk.py
@@ -4,7 +4,9 @@ import injector
 import pytest
 
 from virtual_assistant.routes.talk import blueprint
-from virtual_assistant.watson import WatsonAssistant
+from virtual_assistant.assistant.watson import WatsonAssistant
+from virtual_assistant.assistant import Assistant
+from virtual_assistant.api_types import TalkResponse
 from .. import async_value
 
 from .common import app_with_blueprint
@@ -18,15 +20,14 @@ async def watson() -> MagicMock:
 @pytest.fixture
 async def test_client(watson) -> TestClientProtocol:
     def injector_binder(binder: injector.Binder):
-        binder.bind(WatsonAssistant, watson)
+        binder.bind(Assistant, watson)
 
     return app_with_blueprint(blueprint, injector_binder).test_client()
 
 
 async def test_talk(test_client, watson) -> None:
-    watson.create_session = MagicMock(return_value=async_value("1234"))
-    watson.send_watson_message = MagicMock(
-        return_value=async_value({"output": {"generic": []}})
+    watson.send_message = MagicMock(
+        return_value=async_value(TalkResponse(session_id="x", response=[]))
     )
     response = await test_client.post(
         "/talk",

--- a/services/virtual-assistant/tests/test_config.py
+++ b/services/virtual-assistant/tests/test_config.py
@@ -24,6 +24,7 @@ def clear_app_config():
         "CLOWDER_ENABLED": "true",
         "SESSION_STORAGE": "redis",
         "ACG_CONFIG": path_to_resource("clowdapp-ephemeral.json"),
+        "CONSOLE_ASSISTANT": "watson",
         "WATSON_API_URL": "some-url",
         "WATSON_API_KEY": "my-key",
         "WATSON_ENV_ID": "my-env",

--- a/services/virtual-assistant/tests/test_watson.py
+++ b/services/virtual-assistant/tests/test_watson.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from virtual_assistant.watson import WatsonAssistantImpl, build_assistant
+from virtual_assistant.assistant.watson import WatsonAssistant, build_assistant
 from ibm_watson import AssistantV2
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
@@ -23,8 +23,8 @@ def environment_id():
 
 
 @pytest.fixture
-def watson(assistant_v2, assistant_id, environment_id) -> WatsonAssistantImpl:
-    return WatsonAssistantImpl(assistant_v2, assistant_id, environment_id)
+def watson(assistant_v2, assistant_id, environment_id) -> WatsonAssistant:
+    return WatsonAssistant(assistant_v2, assistant_id, environment_id)
 
 
 async def test_build_assistant():
@@ -34,7 +34,7 @@ async def test_build_assistant():
 
 
 async def test_create_session_with_existing_session(watson, assistant_v2):
-    session_id = await watson.create_session("1234")
+    session_id = await watson.ensure_session_id("1234")
     assert session_id == "1234"
     assistant_v2.create_session.assert_not_called()
 
@@ -44,13 +44,13 @@ async def test_create_session_without_session(watson, assistant_v2):
     create_session_return.get_result = MagicMock(return_value={"session_id": "1234"})
     assistant_v2.create_session = MagicMock(return_value=create_session_return)
 
-    session_id = await watson.create_session()
+    session_id = await watson.ensure_session_id()
     assert session_id == "1234"
     assistant_v2.create_session.assert_called_once()
 
 
 async def test_send_watson_message(watson, assistant_v2, assistant_id, environment_id):
-    await watson.send_watson_message(session_id="1234", user_id="1234", input={})
+    await watson.send_message(session_id="1234", user_id="1234", message={})
     assistant_v2.message.assert_called_once()
     assistant_v2.message.assert_called_with(
         assistant_id=assistant_id,

--- a/services/watson-extension/src/run.py
+++ b/services/watson-extension/src/run.py
@@ -44,7 +44,7 @@ QuartSchema(
     ),
     servers=[
         Server(
-            url=f"https://{{env}}{config.base_url}",
+            url="https://{env}",
             description="Virtual assistant watson extension",
             variables={
                 "env": ServerVariable(
@@ -56,6 +56,10 @@ QuartSchema(
                     description="Available environments",
                 )
             },
+        ),
+        Server(
+            url=f"http://127.0.0.1:{config.port}",
+            description="Local development server",
         ),
     ],
     security_schemes={


### PR DESCRIPTION
 - Instead of always using WatsonAssistant, create the abstraction of assistant to allow to use different kinds of backends as required or turn off this (i.e. for ephemeral environments)
 - Some tweaks on the openapi (adding a dev environment) and fixes the base url.
 - Allows to select assistant (watson/echo) and moves the TalkResponse up to the assistant (instead of having the format_response outside)