### PR TITLE
Patch openapi to be 3.0.0 compliant

### DIFF
--- a/services/virtual-assistant/src/run.py
+++ b/services/virtual-assistant/src/run.py
@@ -10,7 +10,7 @@ from quart_schema import (
 import virtual_assistant.config as config
 
 from common.logging import build_logger
-from common.quart_schema import VirtualAssistantOpenAPIProvider
+from virtual_assistant.quart_schema import VirtualAssistantOpenAPIProvider
 from common.types.errors import ValidationError
 from virtual_assistant.startup import wire_routes, injector_from_config
 
@@ -28,7 +28,7 @@ async def handle_request_validation_error(error):
 
 
 # Must happen after routes, injector, etc
-QuartSchema(
+schema = QuartSchema(
     app,
     openapi_path=config.base_url + "/openapi.json",
     openapi_provider_class=VirtualAssistantOpenAPIProvider,
@@ -58,6 +58,9 @@ QuartSchema(
         ),
     ],
 )
+
+# Add openapi path to our temporal -v2 path
+app.add_url_rule("/api/virtual-assistant-v2/v2/openapi.json", "openapi", schema.openapi)
 
 if __name__ == "__main__":
     app.run(port=config.port)

--- a/services/virtual-assistant/src/virtual_assistant/quart_schema.py
+++ b/services/virtual-assistant/src/virtual_assistant/quart_schema.py
@@ -1,19 +1,15 @@
-from typing import Iterable, Dict, Any, Tuple
+from typing import Iterable, Tuple
 
 from quart_schema import OpenAPIProvider
 from quart_schema.openapi import Rule
 
 
 class VirtualAssistantOpenAPIProvider(OpenAPIProvider):
-    def schema(self) -> Dict[str, Any]:
-        schema = super().schema()
-        schema["openapi"] = "3.0.0"
-        return schema
-
     def build_paths(self, rule: Rule) -> Tuple[dict, dict]:
         paths, components = super().build_paths(rule)
         if rule.endpoint.startswith("public_root_alias"):
             return dict(), dict()
+
         return paths, components
 
     def generate_rules(self) -> Iterable[Rule]:

--- a/services/virtual-assistant/src/virtual_assistant/routes/talk.py
+++ b/services/virtual-assistant/src/virtual_assistant/routes/talk.py
@@ -35,7 +35,7 @@ class TalkInput(BaseModel):
 class TalkRequest(BaseModel):
     """Request data for talk endpoint."""
 
-    session_id: Optional[str]
+    session_id: Optional[str] = None
     """User session id. Do not send if we want to start a new session"""
 
     input: TalkInput

--- a/services/watson-extension/src/run.py
+++ b/services/watson-extension/src/run.py
@@ -2,7 +2,6 @@ import quart_injector
 from quart import Quart
 import watson_extension.config as config
 from common.logging import build_logger
-from common.quart_schema import VirtualAssistantOpenAPIProvider
 
 from quart_schema import (
     QuartSchema,
@@ -13,6 +12,7 @@ from quart_schema import (
 )
 
 from common.types.errors import ValidationError
+from watson_extension.quart_schema import WatsonExtensionAPIProvider
 from watson_extension.startup import (
     wire_routes,
     injector_from_config,
@@ -36,7 +36,7 @@ async def handle_request_validation_error(error):
 QuartSchema(
     app,
     openapi_path=config.base_url + "/openapi.json",
-    openapi_provider_class=VirtualAssistantOpenAPIProvider,
+    openapi_provider_class=WatsonExtensionAPIProvider,
     info=Info(
         title="Virtual assistant watson extension",
         version="2.0.0",
@@ -67,15 +67,17 @@ QuartSchema(
             "type": "oauth2",
             "flows": {
                 "clientCredentials": {
-                    "tokenUrl": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
-                }
+                    "tokenUrl": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+                    "scopes": {},
+                },
             },
         },
         "service2service-stage": {
             "type": "oauth2",
             "flows": {
                 "clientCredentials": {
-                    "tokenUrl": "https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+                    "tokenUrl": "https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+                    "scopes": {},
                 }
             },
         },

--- a/services/watson-extension/src/watson_extension/quart_schema.py
+++ b/services/watson-extension/src/watson_extension/quart_schema.py
@@ -1,0 +1,98 @@
+from typing import Dict, Any, Tuple, List, Type, Optional, Iterable
+
+from quart_schema import DataSource, OpenAPIProvider
+from quart_schema.openapi import Model, Rule
+
+
+# Given the requirements [1] for a watson extension, we cannot use openapi 3.1.0 or anyOf, oneOf, allOf, among other things.
+# We will have to patch them or maintain manually the API for the watson-extension.
+# We can try to patch the openapi file as long as we can.
+#
+# [1] https://cloud.ibm.com/docs/watson-assistant/watson-assistant?topic=watson-assistant-build-custom-extension
+class WatsonExtensionAPIProvider(OpenAPIProvider):
+    def schema(self) -> Dict[str, Any]:
+        schema = super().schema()
+        schema["openapi"] = "3.0.0"
+        return schema
+
+    def generate_rules(self) -> Iterable[Rule]:
+        for rule in super().generate_rules():
+            # This static endpoints gets added when using quart-injector - unsure if it's a dev only rule, but hiding from here.
+            if rule.endpoint == "static":
+                continue
+
+            yield rule
+
+    def build_paths(self, rule: Rule) -> Tuple[dict, dict]:
+        paths, components = super().build_paths(rule)
+
+        if rule.endpoint.startswith("public_root_alias"):
+            return dict(), dict()
+
+        for component in components.values():
+            self._patch_schema(component)
+
+        return paths, components
+
+    def build_querystring_parameters(
+        self, model: Type[Model]
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        parameters, definitions = super().build_querystring_parameters(model)
+        for parameter in parameters:
+            if "schema" in parameter:
+                self._patch_schema(parameter["schema"])
+        return parameters, definitions
+
+    def build_request_body(
+        self, model: Type[Model], source: DataSource
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        request_body, definitions = super().build_request_body(model, source)
+        if "content" in request_body:
+            content = request_body["content"]
+            for content_type in content:
+                if "schema" in content[content_type]:
+                    self._patch_schema(content[content_type]["schema"])
+
+        return request_body, definitions
+
+    def build_response_object(
+        self, model: Type[Model], headers_model: Optional[Type[Model]]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        response, definitions = super().build_response_object(model, headers_model)
+        if "content" in response:
+            content = response["content"]
+            for content_type in content:
+                if "schema" in content[content_type]:
+                    self._patch_schema(content[content_type]["schema"])
+        return response, definitions
+
+    def _patch_schema(self, schema: Dict[str, Any]):
+        if schema.get("type", "") == "object":
+            for property_key in schema.get("properties", []):
+                prop = schema.get("properties")[property_key]
+                self._patch_schema(prop)
+
+        if "anyOf" in schema:
+            schema["anyOf"] = [
+                v for v in schema["anyOf"] if not self._is_type_with_null_string(v)
+            ]
+            if len(schema["anyOf"]) == 1:
+                content = schema["anyOf"][0]
+                if set(content.keys()).isdisjoint(schema):
+                    if "default" in schema:
+                        del schema["default"]
+
+                    for content_key in content:
+                        schema[content_key] = content[content_key]
+                    schema["anyOf"] = []
+
+            if len(schema["anyOf"]) == 0:
+                del schema["anyOf"]
+
+        if "const" in schema:
+            if "enum" not in schema:
+                schema["enum"] = [schema["const"]]
+            del schema["const"]
+
+    def _is_type_with_null_string(self, value: dict[str, Any]) -> bool:
+        return len(value) == 1 and "type" in value and value["type"] == "null"


### PR DESCRIPTION
 - Watsonx Assistant does not yet support 3.1.0, so we need to manually patch some of these elements to support 3.0.0
 - quart-schema doesnt support either to specify a lower version
 - virtual-assistant will use 3.0.1
- openapi.json is also exposed on virtual-assistant-v2/v2/openapi.json
