### PR TITLE
Use public advisor openshift endpoint

### DIFF
--- a/services/watson-extension/src/watson_extension/config.py
+++ b/services/watson-extension/src/watson_extension/config.py
@@ -23,7 +23,7 @@ content_sources_url = config(
     "ENDPOINT__CONTENT_SOURCES_BACKEND__SERVICE__URL", default=__platform_url
 )
 advisor_openshift_url = config(
-    "PRIVATE_ENDPOINT__CCX_SMART_PROXY__SERVICE__URL", default=__platform_url
+    "ENDPOINT__CCX_SMART_PROXY__SERVICE__URL", default=__platform_url
 )
 
 # Platform requests

--- a/services/watson-extension/tests/resources/app_test/default_clowdapp.json
+++ b/services/watson-extension/tests/resources/app_test/default_clowdapp.json
@@ -70,6 +70,12 @@
       "hostname": "rbac-service.svc",
       "name": "service",
       "port": 8000
+    },
+    {
+      "app": "ccx-smart-proxy",
+      "hostname": "openshift-advisor",
+      "name": "service",
+      "port": 8000
     }
   ],
   "privateEndpoints": [
@@ -79,12 +85,6 @@
       "name":"actions",
       "port":10000,
       "tlsPort":0
-    },
-    {
-      "app": "ccx-smart-proxy",
-      "hostname": "openshift-advisor",
-      "name": "service",
-      "port": 8000
     }
   ],
   "kafka": {


### PR DESCRIPTION
 - It looks like it is not using the private endpoint. 

edit: Just checked v1 and we are using the public one there - no idea why I'm using it as private :'( 

From the logs:

ccx-smart-proxy-service
```
...
{"level":"info","time":"2025-04-02T12:10:58Z","message":"Starting HTTP server at ':8000'"}
{"level":"info","time":"2025-04-02T12:10:58Z","message":"Initializing HTTP server at ':8000'"}
...
```
