### PR TITLE
Fix uhc-auth and raise an error on any missing key

### DIFF
--- a/libs/common/src/common/auth.py
+++ b/libs/common/src/common/auth.py
@@ -30,15 +30,23 @@ def require_identity_header(func):
 def assistant_user_id(identity):
     decoded_identity = base64.b64decode(identity).decode("utf8")
     identity_wrapper = json.loads(decoded_identity)
-    identity_json = identity_wrapper.get("identity")
+    identity_json = identity_wrapper["identity"]
 
-    org_id = identity_json.get("org_id")
-    identity_type = identity_json.get("type")
+    org_id = identity_json["org_id"]
+    identity_type = identity_json["type"]
     if identity_type == "ServiceAccount":
-        user_id = identity_json.get("service_account").get("user_id")
+        user_id = identity_json["service_account"]["user_id"]
     elif identity_type == "User":
-        user_id = identity_json.get("user").get("user_id")
+        user_id = identity_json["user"]["user_id"]
     elif identity_type == "System":
-        user_id = identity_json.get("system").get("cn")
+        auth_type = identity_json["auth_type"]
+        if auth_type == "uhc-auth":
+            user_id = "cluster-" + identity_json["system"]["cluster_id"]
+        elif auth_type == "cert-auth":
+            user_id = identity_json["system"]["cn"]
+        else:
+            raise ValueError(f"Invalid auth_type for System identity: {auth_type}")
+    else:
+        raise ValueError(f"Invalid identity_type identity: {identity_type}")
 
     return f"{org_id}/{user_id}"

--- a/libs/common/tests/common/test_auth.py
+++ b/libs/common/tests/common/test_auth.py
@@ -32,4 +32,4 @@ async def test_identity_service_account():
 
 async def test_identity_uhc():
     token = load_and_base64encode_resource("identities/uhc.json")
-    assert assistant_user_id(token) == "321/c87dcb4c-8af1-40dd-878e-60c744edddd0"
+    assert assistant_user_id(token) == "321/cluster-456"

--- a/libs/common/tests/resources/identities/uhc.json
+++ b/libs/common/tests/resources/identities/uhc.json
@@ -4,13 +4,12 @@
     "org_id": "321",
     "type": "System",
     "auth_type": "uhc-auth",
+    "system": {
+      "cluster_id": "456"
+    },
     "internal": {
       "org_id": "321",
       "auth_time": 1
-    },
-    "system": {
-      "cert_type": "system",
-      "cn": "c87dcb4c-8af1-40dd-878e-60c744edddd0"
     }
   },
   "entitlements": {}


### PR DESCRIPTION
I was forgetting to update this part on response to https://github.com/RedHatInsights/identity-schemas/pull/8/files

Also updated that instead of using the safe `get` we use array subscript to get a `KeyError` if anything is missing