### PR TITLE
Adding platform_request metric to track of external requests

### DIFF
--- a/libs/common/src/common/metrics/__init__.py
+++ b/libs/common/src/common/metrics/__init__.py
@@ -1,0 +1,26 @@
+from typing import Optional, TypeVar
+
+from aioprometheus import Registry
+from aioprometheus.collectors import Collector, LabelsType
+
+T = TypeVar("T", bound=Collector)
+
+
+def get_or_create_metric(
+    registry: Registry,
+    name: str,
+    collector: type[T],
+    doc: str,
+    const_labels: Optional[LabelsType] = None,
+    **kwargs,
+) -> T:
+    if name in registry.collectors:
+        metric = registry.get(name)
+        if type(metric) is not collector:
+            raise ValueError(
+                f"Metric {name} was requested with a different type that it was originally built. {type(metric).__name__} is not {collector.__name__}"
+            )
+        return metric
+    return collector(
+        name=name, doc=doc, const_labels=const_labels, registry=registry, **kwargs
+    )

--- a/libs/common/src/common/metrics/quart.py
+++ b/libs/common/src/common/metrics/quart.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import Callable, Optional
 
@@ -65,7 +66,12 @@ def register_http_metrics(
                 "status": str(response.status_code),
             }
 
-            http_requests_total.inc(labels)
-            http_request_duration.observe(labels, duration)
+            try:
+                http_requests_total.inc(labels)
+                http_request_duration.observe(labels, duration)
+            except Exception as e:
+                logging.getLogger(__name__).error(
+                    "Failed to send platform_request metrics", e
+                )
 
         return response

--- a/libs/common/src/common/platform_request/tracked_platform_request.py
+++ b/libs/common/src/common/platform_request/tracked_platform_request.py
@@ -1,0 +1,74 @@
+import time
+from typing import Optional
+
+from common.platform_request import AbstractPlatformRequest
+from aioprometheus import Counter, Histogram, Registry
+from aiohttp import ClientResponse
+
+_REQUEST_TOTAL_METRIC_NAME = "platform_requests_total"
+_REQUEST_DURATION_METRIC_NAME = "platform_request_duration_seconds"
+
+
+class TrackedPlatformRequest(AbstractPlatformRequest):
+    def __init__(
+        self,
+        platform_request: AbstractPlatformRequest,
+        registry: Registry,
+        app_name: str,
+    ):
+        self.request_total = (
+            registry.get(_REQUEST_TOTAL_METRIC_NAME)
+            if _REQUEST_TOTAL_METRIC_NAME in registry.collectors
+            else Counter(
+                _REQUEST_TOTAL_METRIC_NAME,
+                "Total number of Platform requests",
+                registry=registry,
+                const_labels={"app": app_name},
+            )
+        )
+        self.request_duration = (
+            registry.get(_REQUEST_DURATION_METRIC_NAME)
+            if _REQUEST_DURATION_METRIC_NAME in registry.collectors
+            else Histogram(
+                _REQUEST_DURATION_METRIC_NAME,
+                "Duration of Platform requests in seconds",
+                buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
+                registry=registry,
+                const_labels={"app": app_name},
+            )
+        )
+        self.platform_request = platform_request
+
+    async def request(
+        self,
+        method: str,
+        base_url: str,
+        api_path: str,
+        user_identity: Optional[str] = None,
+        **kwargs,
+    ) -> ClientResponse:
+        start = time.monotonic()
+        status = "unknown"
+        try:
+            response = await self.platform_request.request(
+                method, base_url, api_path, user_identity, **kwargs
+            )
+            status = str(response.status)
+            return response
+        except Exception:
+            status = "exception"
+            raise
+        finally:
+            duration = time.monotonic() - start
+            labels = {
+                "service": base_url,
+                "method": method,
+                "path": api_path,
+                "status": status,
+            }
+
+            if user_identity is not None:
+                labels["authenticated"] = "true"
+
+            self.request_total.inc(labels)
+            self.request_duration.observe(labels, duration)

--- a/libs/common/src/common/platform_request/tracked_platform_request.py
+++ b/libs/common/src/common/platform_request/tracked_platform_request.py
@@ -1,6 +1,8 @@
+import logging
 import time
 from typing import Optional
 
+from common.metrics import get_or_create_metric
 from common.platform_request import AbstractPlatformRequest
 from aioprometheus import Counter, Histogram, Registry
 from aiohttp import ClientResponse
@@ -16,27 +18,23 @@ class TrackedPlatformRequest(AbstractPlatformRequest):
         registry: Registry,
         app_name: str,
     ):
-        self.request_total = (
-            registry.get(_REQUEST_TOTAL_METRIC_NAME)
-            if _REQUEST_TOTAL_METRIC_NAME in registry.collectors
-            else Counter(
-                _REQUEST_TOTAL_METRIC_NAME,
-                "Total number of Platform requests",
-                registry=registry,
-                const_labels={"app": app_name},
-            )
+        self.request_total = get_or_create_metric(
+            registry,
+            _REQUEST_TOTAL_METRIC_NAME,
+            Counter,
+            "Total number of Platform requests",
+            const_labels={"app": app_name},
         )
-        self.request_duration = (
-            registry.get(_REQUEST_DURATION_METRIC_NAME)
-            if _REQUEST_DURATION_METRIC_NAME in registry.collectors
-            else Histogram(
-                _REQUEST_DURATION_METRIC_NAME,
-                "Duration of Platform requests in seconds",
-                buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
-                registry=registry,
-                const_labels={"app": app_name},
-            )
+
+        self.request_duration = get_or_create_metric(
+            registry,
+            _REQUEST_DURATION_METRIC_NAME,
+            Histogram,
+            "Duration of Platform requests in seconds",
+            const_labels={"app": app_name},
+            buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
         )
+
         self.platform_request = platform_request
 
     async def request(
@@ -70,5 +68,10 @@ class TrackedPlatformRequest(AbstractPlatformRequest):
             if user_identity is not None:
                 labels["authenticated"] = "true"
 
-            self.request_total.inc(labels)
-            self.request_duration.observe(labels, duration)
+            try:
+                self.request_total.inc(labels)
+                self.request_duration.observe(labels, duration)
+            except Exception as e:
+                logging.getLogger(__name__).error(
+                    "Failed to send platform_request metrics", e
+                )

--- a/libs/common/src/common/providers.py
+++ b/libs/common/src/common/providers.py
@@ -1,57 +1,73 @@
 from typing import Optional
 
 import aiohttp
+from quart import Quart
 from injector import Inject, CallableT, provider
 from redis.asyncio import StrictRedis
 
+from common.metrics.quart import get_registry
 from common.platform_request import (
     DevPlatformRequest,
     ServiceAccountPlatformRequest,
     PlatformRequest,
+    AbstractPlatformRequest,
 )
+from common.platform_request.tracked_platform_request import TrackedPlatformRequest
 from common.session_storage.file import FileSessionStorage
 from common.session_storage.redis import RedisSessionStorage
 
 
 def make_dev_platform_request_provider(
-    refresh_token: str, refresh_token_url: str
+    refresh_token: str, refresh_token_url: str, app_name: str
 ) -> CallableT:
     @provider
     def dev_platform_request(
-        session: Inject[aiohttp.ClientSession],
-    ) -> DevPlatformRequest:
-        return DevPlatformRequest(
-            session,
-            refresh_token=refresh_token,
-            refresh_token_url=refresh_token_url,
+        session: Inject[aiohttp.ClientSession], app: Inject[Quart]
+    ) -> AbstractPlatformRequest:
+        return TrackedPlatformRequest(
+            DevPlatformRequest(
+                session,
+                refresh_token=refresh_token,
+                refresh_token_url=refresh_token_url,
+            ),
+            get_registry(app),
+            app_name,
         )
 
     return dev_platform_request
 
 
 def make_sa_platform_request_provider(
-    token_url: str, sa_id: str, sa_secret: str
+    token_url: str, sa_id: str, sa_secret: str, app_name: str
 ) -> CallableT:
     @provider
     def sa_platform_request(
         session: Inject[aiohttp.ClientSession],
-    ) -> ServiceAccountPlatformRequest:
-        return ServiceAccountPlatformRequest(
-            session,
-            token_url=token_url,
-            sa_id=sa_id,
-            sa_secret=sa_secret,
+        app: Inject[Quart],
+    ) -> AbstractPlatformRequest:
+        return TrackedPlatformRequest(
+            ServiceAccountPlatformRequest(
+                session,
+                token_url=token_url,
+                sa_id=sa_id,
+                sa_secret=sa_secret,
+            ),
+            get_registry(app),
+            app_name,
         )
 
     return sa_platform_request
 
 
-def make_platform_request_provider() -> CallableT:
+def make_platform_request_provider(app_name: str) -> CallableT:
     @provider
     def platform_request(
         session: Inject[aiohttp.ClientSession],
-    ) -> PlatformRequest:
-        return PlatformRequest(session)
+        app: Inject[Quart],
+    ) -> AbstractPlatformRequest:
+        return TrackedPlatformRequest(
+            PlatformRequest(session), get_registry(app), app_name
+        )
 
     return platform_request
 

--- a/libs/common/tests/common/test_metrics.py
+++ b/libs/common/tests/common/test_metrics.py
@@ -1,0 +1,80 @@
+import pytest
+from aioprometheus import Registry, Gauge, Histogram
+
+from common.metrics import get_or_create_metric
+
+
+def test_get_or_create_metric():
+    registry = Registry()
+
+    with pytest.raises(KeyError):
+        registry.get("not_found")
+
+    gauge = get_or_create_metric(registry, "not_found", Gauge, "doc")
+
+    assert gauge is not None
+    assert gauge == registry.get("not_found")
+    assert gauge == get_or_create_metric(registry, "not_found", Gauge, "doc")
+
+    assert gauge.name == "not_found"
+    assert gauge.doc == "doc"
+
+    with pytest.raises(KeyError):
+        registry.get("not_found_histogram")
+
+
+def test_get_or_create_metric_with_extra_args():
+    registry = Registry()
+    histogram = get_or_create_metric(
+        registry,
+        "not_found_histogram",
+        Histogram,
+        doc="doc_histogram",
+        const_labels={"app": "test"},
+        buckets=[0.1, 0.2, 0.5],
+    )
+
+    assert histogram is not None
+    assert histogram == registry.get("not_found_histogram")
+
+    assert histogram.name == "not_found_histogram"
+    assert histogram.doc == "doc_histogram"
+    assert histogram.const_labels == {"app": "test"}
+    assert histogram.upper_bounds == [0.1, 0.2, 0.5]
+
+
+def test_get_or_create_metric_redefine():
+    registry = Registry()
+    get_or_create_metric(
+        registry,
+        "not_found_histogram",
+        Histogram,
+        doc="doc_histogram",
+        const_labels={"app": "test"},
+        buckets=[0.1, 0.2, 0.5],
+    )
+
+    with pytest.raises(ValueError) as execinfo:
+        get_or_create_metric(registry, "not_found_histogram", Gauge, doc="redefining")
+    assert (
+        str(execinfo.value)
+        == "Metric not_found_histogram was requested with a different type that it was originally built. Histogram is not Gauge"
+    )
+
+
+def test_get_or_create_metric_different_registries():
+    registry = Registry()
+    registry2 = Registry()
+    histogram = get_or_create_metric(
+        registry,
+        "not_found_histogram",
+        Histogram,
+        doc="doc_histogram",
+        const_labels={"app": "test"},
+        buckets=[0.1, 0.2, 0.5],
+    )
+    gauge = get_or_create_metric(
+        registry2, "not_found_histogram", Gauge, doc="redefining in other registry"
+    )
+
+    assert histogram is not gauge

--- a/services/virtual-assistant/src/run.py
+++ b/services/virtual-assistant/src/run.py
@@ -20,6 +20,7 @@ config.log_config()
 app = Quart(__name__)
 
 wire_routes(app)
+quart_injector.QuartModule(app)
 quart_injector.wire(app, injector_from_config)
 quart_metrics.register_app(app)
 quart_metrics.register_http_metrics(

--- a/services/virtual-assistant/src/virtual_assistant/startup.py
+++ b/services/virtual-assistant/src/virtual_assistant/startup.py
@@ -117,6 +117,7 @@ def injector_from_config(binder: injector.Binder) -> None:
             to=make_dev_platform_request_provider(
                 refresh_token=config.dev_platform_request_offline_token,
                 refresh_token_url=config.dev_platform_request_refresh_url,
+                app_name=config.name,
             ),
             scope=injector.singleton,
         )
@@ -127,13 +128,14 @@ def injector_from_config(binder: injector.Binder) -> None:
                 token_url=config.sa_platform_request_token_url,
                 sa_id=config.sa_platform_request_id,
                 sa_secret=config.sa_platform_request_secret,
+                app_name=config.name,
             ),
             scope=injector.singleton,
         )
     elif config.platform_request == "platform":
         binder.bind(
             AbstractPlatformRequest,
-            to=make_platform_request_provider(),
+            to=make_platform_request_provider(app_name=config.name),
             scope=injector.singleton,
         )
     else:

--- a/services/watson-extension/src/run.py
+++ b/services/watson-extension/src/run.py
@@ -25,6 +25,7 @@ app = Quart(__name__)
 config.log_config()
 
 wire_routes(app)
+quart_injector.QuartModule(app)
 quart_injector.wire(app, [injector_defaults, injector_from_config])
 quart_metrics.register_app(app)
 quart_metrics.register_http_metrics(

--- a/services/watson-extension/src/watson_extension/startup.py
+++ b/services/watson-extension/src/watson_extension/startup.py
@@ -115,6 +115,7 @@ def injector_from_config(binder: injector.Binder) -> None:
             to=make_dev_platform_request_provider(
                 refresh_token=config.dev_platform_request_offline_token,
                 refresh_token_url=config.dev_platform_request_refresh_url,
+                app_name=config.name,
             ),
             scope=injector.singleton,
         )
@@ -125,13 +126,14 @@ def injector_from_config(binder: injector.Binder) -> None:
                 token_url=config.sa_platform_request_token_url,
                 sa_id=config.sa_platform_request_id,
                 sa_secret=config.sa_platform_request_secret,
+                app_name=config.name,
             ),
             scope=injector.singleton,
         )
     elif config.platform_request == "platform":
         binder.bind(
             AbstractPlatformRequest,
-            to=make_platform_request_provider(),
+            to=make_platform_request_provider(app_name=config.name),
             scope=injector.singleton,
         )
     else:


### PR DESCRIPTION
- lightspeed and all services in watson-extension
 - platform_request_duration and platform_request_count
 - labels: app, authenticated, method, path and service

# Example output
```
# HELP http_request_duration_seconds HTTP request latency in seconds
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.005",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.01",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.025",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.05",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.1",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.25",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="0.5",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="1.0",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 0.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="2.5",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 1.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="5.0",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 1.0
http_request_duration_seconds_bucket{app="virtual-assistant",le="+Inf",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 2.0
http_request_duration_seconds_count{app="virtual-assistant",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 2.0
http_request_duration_seconds_sum{app="virtual-assistant",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 12.733062907063868
# HELP http_requests_total Total number of HTTP requests
# TYPE http_requests_total counter
http_requests_total{app="virtual-assistant",method="POST",path="/api/virtual-assistant/v2/talk",status="200"} 2
# HELP platform_request_duration_seconds Duration of Platform requests in seconds
# TYPE platform_request_duration_seconds histogram
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="0.01",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="0.05",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="0.1",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="0.25",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="0.5",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="1.0",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="2.5",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 0.0
platform_request_duration_seconds_bucket{app="virtual-assistant",authenticated="true",le="+Inf",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 1.0
platform_request_duration_seconds_count{app="virtual-assistant",authenticated="true",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 1.0
platform_request_duration_seconds_sum{app="virtual-assistant",authenticated="true",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 10.78639392805053
# HELP platform_requests_total Total number of Platform requests
# TYPE platform_requests_total counter
platform_requests_total{app="virtual-assistant",authenticated="true",method="POST",path="/api/lightspeed/v1/infer",service="https://console.stage.redhat.com",status="200"} 1

```

## Summary by Sourcery

Add platform request metrics tracking for external requests across services

New Features:
- Implement platform request metrics with labels for app, authenticated status, method, path, and service

Enhancements:
- Create a TrackedPlatformRequest wrapper to add metrics to existing platform request implementations
- Extend platform request providers to support metrics tracking

Chores:
- Update startup configurations for virtual-assistant and watson-extension services to include app name in metrics