### PR TITLE
Using a different port for metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pydantic>=2.10.5",
     "logstash_formatter>=0.5.17",
     "aiohttp>=3.11.11",
-    "aioprometheus[quart]>=23.12.0",
+    "aioprometheus[aiohttp]>=23.12.0",
 ]
 
 [dependency-groups]

--- a/services/virtual-assistant/src/run.py
+++ b/services/virtual-assistant/src/run.py
@@ -22,7 +22,7 @@ app = Quart(__name__)
 wire_routes(app)
 quart_injector.QuartModule(app)
 quart_injector.wire(app, injector_from_config)
-quart_metrics.register_app(app)
+quart_metrics.register_app(app, port=config.metrics_port)
 quart_metrics.register_http_metrics(
     app, config.name, lambda r: r.path.startswith("/api")
 )

--- a/services/virtual-assistant/src/virtual_assistant/config.py
+++ b/services/virtual-assistant/src/virtual_assistant/config.py
@@ -8,6 +8,8 @@ base_url = config("BASE_URL", default="/api/virtual-assistant/v2/")
 port = config("PORT", default=5000, cast=int)
 environment_name = config("ENVIRONMENT_NAME", default="stage", cast=str)
 
+metrics_port = config("METRICS_PORT", default=0, cast=int)
+
 is_running_locally = config("IS_RUNNING_LOCALLY", default=False, cast=bool)
 if is_running_locally:
     __platform_url = config("PLATFORM_URL", default="https://console.redhat.com")

--- a/services/watson-extension/src/run.py
+++ b/services/watson-extension/src/run.py
@@ -27,7 +27,7 @@ config.log_config()
 wire_routes(app)
 quart_injector.QuartModule(app)
 quart_injector.wire(app, [injector_defaults, injector_from_config])
-quart_metrics.register_app(app)
+quart_metrics.register_app(app, config.metrics_port)
 quart_metrics.register_http_metrics(
     app, config.name, lambda r: r.path.startswith("/api")
 )

--- a/services/watson-extension/src/watson_extension/config.py
+++ b/services/watson-extension/src/watson_extension/config.py
@@ -7,6 +7,8 @@ base_url = config("BASE_URL", default="/api/virtual-assistant-watson-extension/v
 port = config("PORT", default=5050, cast=int)
 environment_name = config("ENVIRONMENT_NAME", default="stage", cast=str)
 
+metrics_port = config("METRICS_PORT", default=0, cast=int)
+
 is_running_locally = config("IS_RUNNING_LOCALLY", default=False, cast=bool)
 if is_running_locally:
     __platform_url = config("PLATFORM_URL", default="https://console.redhat.com")

--- a/uv.lock
+++ b/uv.lock
@@ -90,8 +90,8 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-quart = [
-    { name = "quart" },
+aiohttp = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "aioprometheus", extra = ["quart"] },
+    { name = "aioprometheus", extra = ["aiohttp"] },
     { name = "logstash-formatter" },
     { name = "pydantic" },
     { name = "quart" },
@@ -167,7 +167,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.11" },
-    { name = "aioprometheus", extras = ["quart"], specifier = ">=23.12.0" },
+    { name = "aioprometheus", extras = ["aiohttp"], specifier = ">=23.12.0" },
     { name = "logstash-formatter", specifier = ">=0.5.17" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "quart", specifier = ">=0.20.0" },


### PR DESCRIPTION
 - Instead of serving in the same port, use a different port to prevent blocking requests on the main port
 - Port uses 0 by default when running locally, but should use the one set by clowder/app-interface