### PR TITLE
Adding image-digest param to sast-coverity-check to fix konflux builds

### DIFF
--- a/.tekton/virtual-assistant-api-v2-pull-request.yaml
+++ b/.tekton/virtual-assistant-api-v2-pull-request.yaml
@@ -422,6 +422,8 @@ spec:
         - "false"
     - name: sast-coverity-check
       params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE

--- a/.tekton/virtual-assistant-api-v2-push.yaml
+++ b/.tekton/virtual-assistant-api-v2-push.yaml
@@ -419,6 +419,8 @@ spec:
         - "false"
     - name: sast-coverity-check
       params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE

--- a/.tekton/virtual-assistant-watson-extension-pull-request.yaml
+++ b/.tekton/virtual-assistant-watson-extension-pull-request.yaml
@@ -422,6 +422,8 @@ spec:
         - "false"
     - name: sast-coverity-check
       params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE

--- a/.tekton/virtual-assistant-watson-extension-push.yaml
+++ b/.tekton/virtual-assistant-watson-extension-push.yaml
@@ -419,6 +419,8 @@ spec:
         - "false"
     - name: sast-coverity-check
       params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Tekton pipeline configurations to include image digest parameter for SAST-Coverity checks in pull request and push workflows