### PR TITLE
Adding RBAC back to routes list

### DIFF
--- a/services/watson-extension/src/watson_extension/routes/insights/notifications.py
+++ b/services/watson-extension/src/watson_extension/routes/insights/notifications.py
@@ -28,7 +28,7 @@ class ResponseSendRbacRequestAdminEmail(BaseModel):
 @validate_querystring(RbacRequestAdminEmail)
 @validate_response(ResponseSendRbacRequestAdminEmail)
 @document_headers(RHSessionIdHeader)
-async def send_rbac_request_admi_email(
+async def send_rbac_request_admin_email(
     query_args: RbacRequestAdminEmail,
     user_identity_provider: injector.Inject[AbstractUserIdentityProvider],
     notifications_service: injector.Inject[NotificationsCore],

--- a/services/watson-extension/src/watson_extension/routes/platform/__init__.py
+++ b/services/watson-extension/src/watson_extension/routes/platform/__init__.py
@@ -1,8 +1,9 @@
 from quart import Blueprint
-from . import chrome, notifications, integrations
+from . import chrome, rbac, notifications, integrations
 
 blueprint = Blueprint("platform", __name__, url_prefix="/platform")
 
 blueprint.register_blueprint(chrome.blueprint)
 blueprint.register_blueprint(notifications.blueprint)
 blueprint.register_blueprint(integrations.blueprint)
+blueprint.register_blueprint(rbac.blueprint)

--- a/services/watson-extension/src/watson_extension/startup.py
+++ b/services/watson-extension/src/watson_extension/startup.py
@@ -67,7 +67,12 @@ from watson_extension.clients.platform.integrations import (
     IntegrationsClient,
     IntegrationsClientHttp,
 )
-from watson_extension.clients.platform.rbac import RbacURL, RBACClient, RBACClientNoOp
+from watson_extension.clients.platform.rbac import (
+    RbacURL,
+    RBACClient,
+    RBACClientHttp,
+    RBACClientNoOp,
+)
 
 
 from common.platform_request import (
@@ -189,6 +194,11 @@ def injector_from_config(binder: injector.Binder) -> None:
         binder.bind(
             NotificationsClient,
             NotificationsClientHttp,
+            scope=quart_injector.RequestScope,
+        )
+        binder.bind(
+            RBACClient,
+            RBACClientHttp,
             scope=quart_injector.RequestScope,
         )
 


### PR DESCRIPTION
Got removed in a rebase or something

## Summary by Sourcery

Re-add RBAC routes and fix a typo in the RBAC request admin email function name

New Features:
- Re-introduced RBAC blueprint to the platform routes

Enhancements:
- Corrected the function name from 'send_rbac_request_admi_email' to 'send_rbac_request_admin_email'