### PR TITLE
Extract params from the feedback command

### DIFF
--- a/services/virtual-assistant/src/virtual_assistant/assistant/__init__.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/__init__.py
@@ -156,6 +156,7 @@ class AssistantOutput(BaseModel):
 class AssistantContext:
     is_internal: bool
     is_org_admin: bool
+    user_email: str
 
 
 class Assistant(ABC):

--- a/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
@@ -48,7 +48,58 @@ def get_debug_output(response: dict) -> dict[str, Any]:
     }
 
 
-def format_response(response: dict) -> List[AssistantResponse]:
+def get_feedback_command_params(watson_msg: str, user_email: str) -> List[Any]:
+    """
+    Extracts the params from the message of the feedback command.
+
+    Example feedback command and params:
+    /feedback <|start_feedback_type|>bug<|end_feedback_type|>
+    <|start_feedback_response|>This is a user feedback<|end_feedback_response|>
+    <|start_usability_study|>false<|end_usability_study|>
+    """
+
+    feedback_type_pattern = r"<\|start_feedback_type\|>(.*?)<\|end_feedback_type\|>"
+    feedback_response_pattern = (
+        r"<\|start_feedback_response\|>(.*?)<\|end_feedback_response\|>"
+    )
+    usability_study_pattern = (
+        r"<\|start_usability_study\|>(.*?)<\|end_usability_study\|>"
+    )
+
+    feedback_type = re.search(feedback_type_pattern, watson_msg).group(1) or "general"
+    feedback_response = re.search(
+        feedback_response_pattern, watson_msg, re.DOTALL
+    ).group(1)  # re.DOTALL handles multiline user feedback response
+
+    usability_study = False
+    usability_study_match = re.search(usability_study_pattern, watson_msg)
+
+    if usability_study_match:
+        usability_study = usability_study_match.group(1) == "true"
+
+    feedback_type_label = feedback_type + "-feedback"
+
+    feedback_usability_study = (
+        "The user DOES NOT want to participate in our usability studies."
+    )
+    if usability_study:
+        feedback_usability_study = (
+            f"The user wants to participate in a usability study. Email: {user_email}"
+        )
+
+    summary = "Platform feedback from the assistant"
+    description = f"""
+    Feedback type: {feedback_type}
+    Feedback: {feedback_response}
+
+    {feedback_usability_study}
+    """
+    labels = ["virtual-assistant", feedback_type_label]
+
+    return [summary, description, labels]
+
+
+def format_response(response: dict, user_email: str) -> List[AssistantResponse]:
     """Formats the message response from watson and maps it to the VA API response for the user
 
     Parameters:
@@ -67,7 +118,14 @@ def format_response(response: dict) -> List[AssistantResponse]:
         if generic["response_type"] == "text":
             if generic["text"].startswith("/"):  # command message
                 params = generic["text"].split(" ")
-                entry = ResponseCommand(command=params[0].strip("/"), args=params[1:])
+                command = params[0].strip("/")
+                if command == "feedback":
+                    feedback_params = get_feedback_command_params(
+                        generic["text"], user_email
+                    )
+                    entry = ResponseCommand(command=command, args=feedback_params)
+                else:
+                    entry = ResponseCommand(command=command, args=params[1:])
             else:
                 entry = ResponseText(
                     text=generic["text"],
@@ -204,6 +262,6 @@ class WatsonAssistant(Assistant):
         return AssistantOutput(
             session_id=message.session_id,
             user_id=message.user_id,
-            response=format_response(response_result),
+            response=format_response(response_result, context.user_email),
             debug_output=debug_output,
         )

--- a/services/virtual-assistant/src/virtual_assistant/routes/talk.py
+++ b/services/virtual-assistant/src/virtual_assistant/routes/talk.py
@@ -119,6 +119,7 @@ async def talk(
             context=AssistantContext(
                 is_internal=identity_json.get("user", {}).get("is_internal", False),
                 is_org_admin=identity_json.get("user", {}).get("is_org_admin", False),
+                user_email=identity_json.get("user", {}).get("email", "no_user_email"),
             ),
         )
 

--- a/services/virtual-assistant/tests/assistant/test_watson.py
+++ b/services/virtual-assistant/tests/assistant/test_watson.py
@@ -1,4 +1,5 @@
 import json
+import textwrap
 from hypothesis import given, strategies as st, settings, HealthCheck
 from unittest.mock import MagicMock
 from .. import get_resource_contents
@@ -149,12 +150,12 @@ async def test_get_feedback_command_params():
     description = extracted_args[1]
     labels = extracted_args[2]
 
-    expected_description = """
+    expected_description = textwrap.dedent("""
     Feedback type: bug
     Feedback: Whoa! Just found this bug!
 
     The user wants to participate in a usability study. Email: user@example.com
-    """
+    """)
 
     assert summary == "Platform feedback from the assistant"
     assert description == expected_description

--- a/services/virtual-assistant/tests/assistant/test_watson.py
+++ b/services/virtual-assistant/tests/assistant/test_watson.py
@@ -16,6 +16,7 @@ from virtual_assistant.assistant.watson import (
     WatsonAssistant,
     build_assistant,
     format_response,
+    get_feedback_command_params,
     WatsonAssistantVariables,
 )
 from ibm_watson import AssistantV2
@@ -71,7 +72,9 @@ async def test_send_watson_message(watson, assistant_v2, assistant_id, environme
         message=AssistantInput(
             session_id="1234", user_id="1234", query=Query(text="hello world")
         ),
-        context=AssistantContext(is_internal=False, is_org_admin=False),
+        context=AssistantContext(
+            is_internal=False, is_org_admin=False, user_email="user@example.com"
+        ),
     )
     assistant_v2.message.assert_called_once()
     assistant_v2.message.assert_called_with(
@@ -106,7 +109,9 @@ async def test_send_draft_variable(
         message=AssistantInput(
             session_id="1234", user_id="1234", query=Query(text="hello world")
         ),
-        context=AssistantContext(is_internal=False, is_org_admin=False),
+        context=AssistantContext(
+            is_internal=False, is_org_admin=False, user_email="user@example.com"
+        ),
     )
     context = assistant_v2.message.call_args.kwargs["context"]
     assert context.skills.actions_skill.skill_variables["Draft"] is draft_value
@@ -122,15 +127,45 @@ async def test_send_assistant_context(
         message=AssistantInput(
             session_id="1234", user_id="1234", query=Query(text="hello world")
         ),
-        context=AssistantContext(is_internal=is_internal, is_org_admin=is_org_admin),
+        context=AssistantContext(
+            is_internal=is_internal,
+            is_org_admin=is_org_admin,
+            user_email="user@example.com",
+        ),
     )
     context = assistant_v2.message.call_args.kwargs["context"]
     assert context.skills.actions_skill.skill_variables["IsInternal"] is is_internal
     assert context.skills.actions_skill.skill_variables["IsOrgAdmin"] is is_org_admin
 
 
+async def test_get_feedback_command_params():
+    watson_message = """/feedback <|start_feedback_type|>bug<|end_feedback_type|>
+    <|start_feedback_response|>Whoa! Just found this bug!<|end_feedback_response|>
+    <|start_usability_study|>true<|end_usability_study|>
+    """
+
+    extracted_args = get_feedback_command_params(watson_message, "user@example.com")
+    summary = extracted_args[0]
+    description = extracted_args[1]
+    labels = extracted_args[2]
+
+    expected_description = """
+    Feedback type: bug
+    Feedback: Whoa! Just found this bug!
+
+    The user wants to participate in a usability study. Email: user@example.com
+    """
+
+    assert summary == "Platform feedback from the assistant"
+    assert description == expected_description
+    assert labels[0] == "virtual-assistant"
+    assert labels[1] == "bug-feedback"
+
+
 async def test_format_response():
-    formatted = format_response(json.loads(get_resource_contents("watson_format.json")))
+    formatted = format_response(
+        json.loads(get_resource_contents("watson_format.json")), "user@example.com"
+    )
     assert len(formatted) == 7
 
     assert formatted[0].type == ResponseType.COMMAND


### PR DESCRIPTION
- Supports the `/feedback` command
- extracts the user email from the identity header and adds it to the `AssistantContext`

Send `foobar 1` to watson to check out the param extraction.

## Summary by Sourcery

Add support for the `/feedback` command by extracting and processing feedback parameters from Watson assistant messages

New Features:
- Implement parsing of feedback command with type, response, and usability study options

Enhancements:
- Extract user email from identity header
- Add user email to AssistantContext