### PR TITLE
Updating feedback command label param to return comma-separated string

### DIFF
--- a/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
@@ -51,7 +51,7 @@ def get_debug_output(response: dict) -> dict[str, Any]:
 
 def get_feedback_command_params(
     watson_msg: str, user_email: str
-) -> Tuple[str, str, List[str]]:
+) -> Tuple[str, str, str]:
     """
     Extracts the params from the message of the feedback command.
 
@@ -102,7 +102,7 @@ def get_feedback_command_params(
 
     {feedback_usability_study}
     """)
-    labels = ["virtual-assistant", feedback_type_label]
+    labels = f"virtual-assistant,{feedback_type_label}"
 
     return [summary, description, labels]
 

--- a/services/virtual-assistant/tests/assistant/test_watson.py
+++ b/services/virtual-assistant/tests/assistant/test_watson.py
@@ -159,8 +159,7 @@ async def test_get_feedback_command_params():
 
     assert summary == "Platform feedback from the assistant"
     assert description == expected_description
-    assert labels[0] == "virtual-assistant"
-    assert labels[1] == "bug-feedback"
+    assert labels == "virtual-assistant,bug-feedback"
 
 
 async def test_format_response():


### PR DESCRIPTION
Frontend seems to expect the label parm as a comma-separated string instead of an array of string.

## Summary by Sourcery

Update feedback command label parameter to return a comma-separated string instead of an array

Bug Fixes:
- Fixed type hint and return value of get_feedback_command_params function to support frontend requirements

Enhancements:
- Modified function to return labels as a comma-separated string to match frontend expectations