### PR TITLE
Adding service account command processing

### DIFF
--- a/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
@@ -49,6 +49,23 @@ def get_debug_output(response: dict) -> dict[str, Any]:
     }
 
 
+def search_for_field(tag: str, watson_msg: str) -> str:
+    """
+    Extracts the params from the message of the feedback command.
+
+    Example feedback command and params:
+    /feedback <|start_feedback_type|>bug<|end_feedback_type|>
+    <|start_feedback_response|>This is a user feedback<|end_feedback_response|>
+    <|start_usability_study|>false<|end_usability_study|>
+    """
+
+    pattern = rf"<\|{tag}\|>(.*?)<\|{tag}\|>"
+    match = re.search(pattern, watson_msg)
+    if not match:
+        raise ValueError(f"Missing {tag} in the message: {watson_msg}")
+    return match.group(1)
+
+
 def get_feedback_command_params(
     watson_msg: str, user_email: str
 ) -> Tuple[str, str, str]:
@@ -107,6 +124,23 @@ def get_feedback_command_params(
     return [summary, description, labels]
 
 
+def get_service_account_command_params(watson_msg: str) -> Tuple[str, str, str]:
+    """
+    Extracts the params from the message of the service account command.
+
+    Example feedback command and params:
+    /create_service_account
+    <|name|>test1<|name|>
+    <|description|>Now, provide a short description for your service account.<|description|>
+    <|environment|>stage<|environment|>
+    """
+    name = search_for_field("name", watson_msg)
+    description = search_for_field("description", watson_msg)
+    environment = search_for_field("environment", watson_msg)
+
+    return [name, description, environment]
+
+
 def format_response(response: dict, user_email: str) -> List[AssistantResponse]:
     """Formats the message response from watson and maps it to the VA API response for the user
 
@@ -132,6 +166,13 @@ def format_response(response: dict, user_email: str) -> List[AssistantResponse]:
                         generic["text"], user_email
                     )
                     entry = ResponseCommand(command=command, args=feedback_params)
+                elif command == "create_service_account":
+                    service_account_params = get_service_account_command_params(
+                        generic["text"]
+                    )
+                    entry = ResponseCommand(
+                        command=command, args=service_account_params
+                    )
                 else:
                     entry = ResponseCommand(command=command, args=params[1:])
             else:

--- a/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
+++ b/services/virtual-assistant/src/virtual_assistant/assistant/watson.py
@@ -108,9 +108,9 @@ def get_service_account_command_params(watson_msg: str) -> Tuple[str, str, str]:
 
     Example feedback command and params:
     /create_service_account
-    <|name|>test1<|name|>
-    <|description|>Now, provide a short description for your service account.<|description|>
-    <|environment|>stage<|environment|>
+    <|start_name|>test1<|end_name|>
+    <|start_description|>Now, provide a short description for your service account.<|end_description|>
+    <|start_environment|>stage<|end_environment|>
     """
     name = search_for_field("name", watson_msg)
     description = search_for_field("description", watson_msg)

--- a/services/virtual-assistant/tests/assistant/test_watson.py
+++ b/services/virtual-assistant/tests/assistant/test_watson.py
@@ -165,9 +165,9 @@ async def test_get_feedback_command_params():
 
 async def test_get_service_account_command_params():
     watson_message = """/create_service_account
-    <|name|>test1<|name|>
-    <|description|>Now, provide a short description for your service account.<|description|>
-    <|environment|>stage<|environment|>
+    <|start_name|>test1<|end_name|>
+    <|start_description|>Now, provide a short description for your service account.<|end_description|>
+    <|start_environment|>stage<|end_environment|>
     """
 
     extracted_args = get_service_account_command_params(watson_message)
@@ -178,6 +178,16 @@ async def test_get_service_account_command_params():
     assert name == "test1"
     assert description == "Now, provide a short description for your service account."
     assert environment == "stage"
+
+
+async def test_get_service_account_command_params_missing_tag():
+    # Test when the <|name|> tag is missing.
+    watson_message_missing_name = """/create_service_account
+    <|start_description|>Now, provide a short description for your service account.<|end_description|>
+    <|start_environment|>stage<|end_environment|>
+    """
+    with pytest.raises(ValueError):
+        get_service_account_command_params(watson_message_missing_name)
 
 
 async def test_format_response():

--- a/services/virtual-assistant/tests/assistant/test_watson.py
+++ b/services/virtual-assistant/tests/assistant/test_watson.py
@@ -18,6 +18,7 @@ from virtual_assistant.assistant.watson import (
     build_assistant,
     format_response,
     get_feedback_command_params,
+    get_service_account_command_params,
     WatsonAssistantVariables,
 )
 from ibm_watson import AssistantV2
@@ -160,6 +161,23 @@ async def test_get_feedback_command_params():
     assert summary == "Platform feedback from the assistant"
     assert description == expected_description
     assert labels == "virtual-assistant,bug-feedback"
+
+
+async def test_get_service_account_command_params():
+    watson_message = """/create_service_account
+    <|name|>test1<|name|>
+    <|description|>Now, provide a short description for your service account.<|description|>
+    <|environment|>stage<|environment|>
+    """
+
+    extracted_args = get_service_account_command_params(watson_message)
+    name = extracted_args[0]
+    description = extracted_args[1]
+    environment = extracted_args[2]
+
+    assert name == "test1"
+    assert description == "Now, provide a short description for your service account."
+    assert environment == "stage"
 
 
 async def test_format_response():


### PR DESCRIPTION
## Summary by Sourcery

Add support for processing service account creation commands in the Watson virtual assistant

New Features:
- Implement parsing of service account creation command with name, description, and environment parameters

Tests:
- Add test case for extracting service account command parameters