### PR TITLE
What is my org id flow

### DIFF
--- a/services/watson-extension/src/templates/platform/rbac/what_is_my_org_id.txt.jinja
+++ b/services/watson-extension/src/templates/platform/rbac/what_is_my_org_id.txt.jinja
@@ -1,0 +1,1 @@
+Your Org ID is {{org_id}}. You can also find it by clicking on your name at the top right of the screen.

--- a/services/watson-extension/src/watson_extension/routes/platform/rbac.py
+++ b/services/watson-extension/src/watson_extension/routes/platform/rbac.py
@@ -66,7 +66,9 @@ async def get_org_id(
     user_identity_provider: injector.Inject[AbstractUserIdentityProvider],
     rbac_core: injector.Inject[RBACCore],
 ) -> OrgIdResponse:
-    user_identity = decoded_identity_header(await user_identity_provider.get_user_identity())
+    user_identity = decoded_identity_header(
+        await user_identity_provider.get_user_identity()
+    )
 
     return OrgIdResponse(
         response=await render_template(

--- a/services/watson-extension/tests/routes/platform/__snapshots__/test_rbac.ambr
+++ b/services/watson-extension/tests/routes/platform/__snapshots__/test_rbac.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_rbac_org_id
+  'Your Org ID is org123. You can also find it by clicking on your name at the top right of the screen.'
+# ---

--- a/services/watson-extension/tests/routes/platform/test_rbac.py
+++ b/services/watson-extension/tests/routes/platform/test_rbac.py
@@ -1,4 +1,3 @@
-from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 import injector
@@ -7,13 +6,10 @@ from quart.typing import TestClientProtocol
 
 from watson_extension.clients.platform.rbac import (
     RBACClient,
-    Roles,
 )
-from watson_extension.core.platform.rbac import RBACCore
 
 from ..common import app_with_blueprint
 from watson_extension.routes.platform.rbac import blueprint
-from ... import async_value
 
 
 @pytest.fixture

--- a/services/watson-extension/tests/routes/platform/test_rbac.py
+++ b/services/watson-extension/tests/routes/platform/test_rbac.py
@@ -1,0 +1,39 @@
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import injector
+import pytest
+from quart.typing import TestClientProtocol
+
+from watson_extension.clients.platform.rbac import (
+    RBACClient,
+    Roles,
+)
+from watson_extension.core.platform.rbac import RBACCore
+
+from ..common import app_with_blueprint
+from watson_extension.routes.platform.rbac import blueprint
+from ... import async_value
+
+
+@pytest.fixture
+async def rbac_client() -> MagicMock:
+    rbac_client = MagicMock(RBACClient)
+    return rbac_client
+
+
+@pytest.fixture
+async def test_client(rbac_client) -> TestClientProtocol:
+    def injector_binder(binder: injector.Binder):
+        binder.bind(RBACClient, rbac_client)
+
+    return app_with_blueprint(blueprint, injector_binder).test_client()
+
+
+async def test_rbac_org_id(test_client, rbac_client, snapshot) -> None:
+    response = await test_client.get(
+        "/rbac/org-id",
+    )
+    assert response.status == "200 OK"
+    data = await response.get_json()
+    assert data["response"] == snapshot


### PR DESCRIPTION
## Summary by Sourcery

Add a new endpoint to retrieve a user's organization ID

New Features:
- Implement a GET /rbac/org-id endpoint that returns the user's organization ID

Tests:
- Add test case for the new org-id endpoint