### PR TITLE
Removing use of platform_request in the services offline client

### DIFF
--- a/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
@@ -25,7 +25,8 @@ class RedhatStatusClientHttp(RedhatStatusClient):
                 ) as status_response:
                     result = await status_response.json()
         except Exception as e:
-            print(
+            logger.error(
                 f"An Exception occured while handling response from status.redhat.com: {e}"
             )
+            raise e
         return result

--- a/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
@@ -1,8 +1,6 @@
 import abc
-import injector
 import logging
-from aiohttp import ClientResponse
-from watson_extension.clients.platform_request import AbstractPlatformRequest
+from aiohttp import ClientResponse, ClientSession
 
 
 logger = logging.getLogger(__name__)
@@ -16,12 +14,18 @@ class RedhatStatusClient(abc.ABC):
 class RedhatStatusClientHttp(RedhatStatusClient):
     def __init__(
         self,
-        platform_request: injector.Inject[AbstractPlatformRequest],
     ):
         super().__init__()
-        self.platform_request = platform_request
 
     async def check_services_offline(self) -> ClientResponse:
-        base_url = "https://status.redhat.com"
-        request = "/api/v2/incidents/unresolved.json"
-        return await self.platform_request.get(base_url, request)
+        try:
+            async with ClientSession() as session:
+                async with session.get(
+                    "https://status.redhat.com/api/v2/incidents/unresolved.json"
+                ) as status_response:
+                    result = await status_response.json()
+        except Exception as e:
+            print(
+                f"An Exception occured while handling response from status.redhat.com: {e}"
+            )
+        return result


### PR DESCRIPTION
## Summary by Sourcery

Remove dependency on platform_request and directly use aiohttp ClientSession for making HTTP requests to Red Hat status service

Enhancements:
- Simplify HTTP request logic by using aiohttp ClientSession directly

Chores:
- Remove dependency on AbstractPlatformRequest injector