### PR TITLE
Trying to fix the ssl issue by setting ssl=False in ClientSession

### DIFF
--- a/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+from typing import Optional, Dict
 from aiohttp import ClientResponse, ClientSession
 
 
@@ -17,9 +18,10 @@ class RedhatStatusClientHttp(RedhatStatusClient):
     ):
         super().__init__()
 
-    async def check_services_offline(self) -> ClientResponse:
+    async def check_services_offline(self) -> Optional[Dict]:
+        result = None
         try:
-            async with ClientSession() as session:
+            async with ClientSession(trust_env=True) as session:
                 async with session.get(
                     "https://status.redhat.com/api/v2/incidents/unresolved.json"
                 ) as status_response:

--- a/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
@@ -22,7 +22,7 @@ class RedhatStatusClientHttp(RedhatStatusClient):
         result = None
         try:
             async with self.session.get(
-                "https://status.redhat.com/api/v2/incidents/unresolved.json"
+                "https://status.redhat.com/api/v2/incidents/unresolved.json", ssl=False
             ) as status_response:
                 result = await status_response.json()
         except Exception as e:

--- a/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
@@ -1,7 +1,8 @@
 import abc
 import logging
 from typing import Optional, Dict
-from aiohttp import ClientResponse, ClientSession
+import injector
+import aiohttp
 
 
 logger = logging.getLogger(__name__)
@@ -9,23 +10,24 @@ logger = logging.getLogger(__name__)
 
 class RedhatStatusClient(abc.ABC):
     @abc.abstractmethod
-    async def check_services_offline(self) -> ClientResponse: ...
+    async def check_services_offline(self) -> Optional[Dict]: ...
 
 
 class RedhatStatusClientHttp(RedhatStatusClient):
     def __init__(
         self,
+        session: injector.Inject[aiohttp.ClientSession]
     ):
         super().__init__()
+        self.session = session
 
     async def check_services_offline(self) -> Optional[Dict]:
         result = None
         try:
-            async with ClientSession(trust_env=True) as session:
-                async with session.get(
-                    "https://status.redhat.com/api/v2/incidents/unresolved.json"
-                ) as status_response:
-                    result = await status_response.json()
+            async with self.session.get(
+                "https://status.redhat.com/api/v2/incidents/unresolved.json"
+            ) as status_response:
+                result = await status_response.json()
         except Exception as e:
             logger.error(
                 f"An Exception occured while handling response from status.redhat.com: {e}"

--- a/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/clients/general/redhat_status.py
@@ -14,10 +14,7 @@ class RedhatStatusClient(abc.ABC):
 
 
 class RedhatStatusClientHttp(RedhatStatusClient):
-    def __init__(
-        self,
-        session: injector.Inject[aiohttp.ClientSession]
-    ):
+    def __init__(self, session: injector.Inject[aiohttp.ClientSession]):
         super().__init__()
         self.session = session
 

--- a/services/watson-extension/src/watson_extension/core/general/redhat_status.py
+++ b/services/watson-extension/src/watson_extension/core/general/redhat_status.py
@@ -29,11 +29,11 @@ class RedhatStatusCore:
     async def check_services_offline(
         self,
     ) -> Tuple[ServicesOfflineResponseTypes, List[IncidentType], str]:
-        result = await self.redhat_status_client.check_services_offline()
-        if not result.ok:
+        content = await self.redhat_status_client.check_services_offline()
+
+        if not content:
             return ServicesOfflineResponseTypes.ERROR, [], "0"
 
-        content = await result.json()
         incidents = content["incidents"]
 
         if incidents:

--- a/services/watson-extension/tests/routes/general/test_redhat_status.py
+++ b/services/watson-extension/tests/routes/general/test_redhat_status.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock
 
 import injector
 import pytest
@@ -29,9 +29,7 @@ async def test_client(redhat_status_client) -> TestClientProtocol:
 async def test_check_services_offline_incident_exists(
     test_client, redhat_status_client
 ) -> None:
-    check_services_offline_response = AsyncMock()
-    check_services_offline_response.ok = True
-    check_services_offline_response.json = MagicMock(
+    redhat_status_client.check_services_offline = MagicMock(
         return_value=async_value(
             {
                 "incidents": [
@@ -43,10 +41,6 @@ async def test_check_services_offline_incident_exists(
                 ]
             }
         )
-    )
-
-    redhat_status_client.check_services_offline = MagicMock(
-        return_value=async_value(check_services_offline_response)
     )
 
     response = await test_client.get("/redhat_status/check_services_offline")
@@ -62,14 +56,8 @@ async def test_check_services_offline_incident_exists(
 async def test_check_services_offline_no_incidents(
     test_client, redhat_status_client
 ) -> None:
-    check_services_offline_response = AsyncMock()
-    check_services_offline_response.ok = True
-    check_services_offline_response.json = MagicMock(
-        return_value=async_value({"incidents": []})
-    )
-
     redhat_status_client.check_services_offline = MagicMock(
-        return_value=async_value(check_services_offline_response)
+        return_value=async_value({"incidents": []})
     )
 
     response = await test_client.get("/redhat_status/check_services_offline")
@@ -82,12 +70,8 @@ async def test_check_services_offline_no_incidents(
 
 
 async def test_check_services_offline_error(test_client, redhat_status_client) -> None:
-    check_services_offline_response = AsyncMock()
-    check_services_offline_response.ok = False
-    check_services_offline_response.json = MagicMock(return_value=async_value({}))
-
     redhat_status_client.check_services_offline = MagicMock(
-        return_value=async_value(check_services_offline_response)
+        return_value=async_value(None)
     )
 
     response = await test_client.get("/redhat_status/check_services_offline")


### PR DESCRIPTION
cc S/O: https://stackoverflow.com/questions/63347818/aiohttp-client-exceptions-clientconnectorerror-cannot-connect-to-host-stackover

## Summary by Sourcery

Modify RedHat status client to handle SSL connection issues by setting trust_env=True and simplify error handling in related methods

Bug Fixes:
- Resolve potential SSL connection issues by enabling environment-based trust settings
- Improve error handling in RedHat status client to handle connection failures gracefully

Enhancements:
- Simplify test mocking for RedHat status client responses
- Streamline error handling in service status checking logic