### PR TITLE
Adding link to newly made activation key

### DIFF
--- a/services/watson-extension/src/templates/insights/inventory/create_activation_keys.txt.jinja
+++ b/services/watson-extension/src/templates/insights/inventory/create_activation_keys.txt.jinja
@@ -2,5 +2,5 @@
 I was unable to create the activation key. Please follow the steps [here](/insights/connector/activation-keys).
 Here's the error message: {{ response.message }}
 {%- else -%}
-Great! I've created the activation key. Configure the system's purpose and workloads on the details page for {{ name }}.
+Great! I've created the activation key. Configure the system's purpose and workloads on the details page for [{{ name }}](/insights/connector/activation-keys/{{name}}).
 {%- endif -%}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include direct link to the newly created activation key in the notification template.