### PR TITLE
build(docker): migrate from UBI 8 to UBI 9 minimal

### DIFF
--- a/docker/Dockerfile.virtual-assistant
+++ b/docker/Dockerfile.virtual-assistant
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv /uv /bin/uv
@@ -13,7 +13,7 @@ ADD uv.lock /app
 
 RUN uv sync --frozen --no-dev --no-editable --directory services/virtual-assistant
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /app
 
 # Copy python

--- a/docker/Dockerfile.watson-extension
+++ b/docker/Dockerfile.watson-extension
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 COPY --from=ghcr.io/astral-sh/uv /uv /bin/uv
@@ -13,7 +13,7 @@ ADD uv.lock /app
 
 RUN uv sync --frozen --no-dev --no-editable --directory services/watson-extension
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /app
 
 # Copy python


### PR DESCRIPTION
## Summary

Migrates both container images from UBI 8 minimal to UBI 9 minimal base image, as approved in the organization-wide migration plan.

**Changes:**
- `docker/Dockerfile.virtual-assistant`: UBI 8 → UBI 9 (builder + runtime stages)
- `docker/Dockerfile.watson-extension`: UBI 8 → UBI 9 (builder + runtime stages)

**Why:** UBI 9 reduces CVE exposure and FedRAMP remediation work. See [UBI 9 minimal catalog](https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5).

Resolves [RHCLOUD-35259](https://redhat.atlassian.net/browse/RHCLOUD-35259)
Parent epic: [RHCLOUD-35236](https://redhat.atlassian.net/browse/RHCLOUD-35236)

[RHCLOUD-35259]: https://redhat.atlassian.net/browse/RHCLOUD-35259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-35236]: https://redhat.atlassian.net/browse/RHCLOUD-35236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Migrate container images to use UBI 9 minimal as the base image for both build and runtime stages.

Build:
- Update virtual-assistant Dockerfile to build and run on UBI 9 minimal instead of UBI 8 minimal.
- Update watson-extension Dockerfile to build and run on UBI 9 minimal instead of UBI 8 minimal.